### PR TITLE
SSCS-12292 - Add Manual Completion Text in 'Next Steps' Field for Manual Completion Post Hearing Tasks

### DIFF
--- a/src/main/resources/wa-task-initiation-sscs-benefit.dmn
+++ b/src/main/resources/wa-task-initiation-sscs-benefit.dmn
@@ -4249,6 +4249,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_14qtv8h">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_036kg0d">
           <text>"sORRequest"</text>
         </inputEntry>
@@ -4830,6 +4831,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0qujved">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_0vohvwb">
           <text>"validSendToInterloc"</text>
         </inputEntry>
@@ -5162,6 +5164,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0i34c9j">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_15ns3oq">
           <text>"libertyToApplyGranted"</text>
         </inputEntry>
@@ -5245,6 +5248,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0luha43">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_0yw2h9x">
           <text>"reviewAndSetAside"</text>
         </inputEntry>
@@ -5494,6 +5498,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1hklqkl">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_1adxuio">
           <text>"sendToFirstTier"</text>
         </inputEntry>
@@ -5660,6 +5665,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0srpxtk">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_0vrd1mv">
           <text>"sendToFirstTier"</text>
         </inputEntry>
@@ -5743,6 +5749,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0h423xq">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_179xtru">
           <text>"libertyToApplyRequest",
 "permissionToAppealRequest",
@@ -5829,6 +5836,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1a0vc32">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_1r24n8t">
           <text>"sORRequest"</text>
         </inputEntry>
@@ -5912,6 +5920,7 @@ contains(scannedDocumentTypes, "videoDocument")</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1yqahxq">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_13f8zt4">
           <text>"sORRequest"</text>
         </inputEntry>

--- a/src/main/resources/wa-task-types-sscs-benefit.dmn
+++ b/src/main/resources/wa-task-types-sscs-benefit.dmn
@@ -494,6 +494,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_04uatuz">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_0alu7px">
           <text></text>
         </inputEntry>
@@ -549,6 +550,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ipditk">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_1irlupc">
           <text></text>
         </inputEntry>
@@ -582,6 +584,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0nefwt8">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_0r11l64">
           <text></text>
         </inputEntry>
@@ -626,6 +629,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_04dyd7k">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_03c6tvh">
           <text></text>
         </inputEntry>
@@ -637,6 +641,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1put3z8">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_029ibvq">
           <text></text>
         </inputEntry>
@@ -659,6 +664,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1vdinki">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_1atto5j">
           <text></text>
         </inputEntry>
@@ -670,6 +676,7 @@
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1pue10z">
+        <description>Manual Completion</description>
         <inputEntry id="UnaryTests_064gjbl">
           <text></text>
         </inputEntry>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-12292

### Change description ###

[CR] Add Manual Completion Text in 'Next Steps' Field for Manual Completion Post Hearing Tasks

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
