### PR TITLE
SSCS-12528 Citizen user uploading audio evidence from MYA is not creating

### DIFF
--- a/src/main/resources/wa-task-initiation-sscs-benefit.dmn
+++ b/src/main/resources/wa-task-initiation-sscs-benefit.dmn
@@ -42,7 +42,7 @@
             null</text>
         </inputExpression>
       </input>
-      <input id="InputClause_0vqvmjn" label="Scanned Document Types" biodi:width="236" camunda:inputVariable="scannedDocumentTypes">
+      <input id="InputClause_0vqvmjn" label="Scanned Document Types" biodi:width="397" camunda:inputVariable="scannedDocumentTypes">
         <inputExpression id="LiteralExpression_1d10a3h" typeRef="string">
           <text>if(additionalData != null and additionalData.Data != null and additionalData.Data.scannedDocumentTypes
             != null) then
@@ -767,7 +767,8 @@ else []</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_5d5h5hd">
-          <text></text>
+          <text>not(contains(scannedDocumentTypes, "audioDocument") or
+contains(scannedDocumentTypes, "videoDocument"))</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1f8ht6b">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/sscstaskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscstaskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -353,12 +353,10 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 .build(),
             event("uploadDocument")
                 .withCaseData("scannedDocumentTypes", List.of("audioDocument"))
-                .initiativesTask("actionUnprocessedCorrespondence", "Action Unprocessed Correspondence - CTSC", 10)
                 .initiativesTask("processAudioVideoEvidence", "Process audio/video evidence - LO", 2)
                 .build(),
             event("dwpSupplementaryResponse")
                 .withCaseData("scannedDocumentTypes", List.of("videoDocument", "audioDocument"))
-                .initiativesTask("actionUnprocessedCorrespondence", "Action Unprocessed Correspondence - CTSC", 10)
                 .initiativesTask("processAudioVideoEvidence", "Process audio/video evidence - LO", 2)
                 .build(),
             event("dwpUploadResponse")
@@ -371,7 +369,6 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 .build(),
             event("uploadDocumentFurtherEvidence")
                 .withCaseData("scannedDocumentTypes", List.of("videoDocument"))
-                .initiativesTask("actionUnprocessedCorrespondence", "Action Unprocessed Correspondence - CTSC", 10)
                 .initiativesTask("processAudioVideoEvidence", "Process audio/video evidence - LO", 2)
                 .build(),
             event("nonCompliant")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-12528

### Change description ###
Task actionUnprocessedCorrespondence not required for audio or video documents, condition added to initiation DMN.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
