### PR TITLE
SSCSCI-1868: migrate from JitPack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,14 +236,17 @@ dependencyManagement {
 
 repositories {
   mavenLocal()
-  maven { url 'https://jitpack.io' }
+  maven {
+    url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
+  }
+  //maven { url 'https://jitpack.io' }
   mavenCentral()
 }
 
 def versions = [
   junit           : '5.12.2',
   junitPlatform   : '1.12.2',
-  reformLogging   : '5.1.7',
+  reformLogging   : '6.1.9',
   camunda         : '7.17.0',
   pitest          : '1.11.3',
   sonarPitest     : '0.5',
@@ -295,6 +298,7 @@ dependencies {
   testImplementation group: 'org.camunda.bpm.assert', name: 'camunda-bpm-assert', version: '8.0.0'
   testImplementation group: 'org.camunda.bpm', name: 'camunda-engine', version: versions.camunda
   testImplementation group: 'com.h2database', name: 'h2', version: '1.4.200'
+  testImplementation group: 'org.apiguardian', name: 'apiguardian-api', version: '1.1.2'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.18'
   id 'com.github.ben-manes.versions' version '0.52.0'
-  id 'org.owasp.dependencycheck' version '10.0.3'
+  id 'org.owasp.dependencycheck' version '12.1.2'
   id 'org.sonarqube' version '4.3.0.3225'
   id 'info.solidsoft.pitest' version '1.9.11'
   id 'io.freefair.lombok' version '8.13.1'

--- a/build.gradle
+++ b/build.gradle
@@ -249,7 +249,7 @@ def versions = [
   camunda         : '7.17.0',
   pitest          : '1.11.3',
   sonarPitest     : '0.5',
-  tomcat          : '9.0.93'
+  tomcat          : '9.0.104'
 ]
 
 ext.libraries = [

--- a/build.gradle
+++ b/build.gradle
@@ -245,7 +245,7 @@ repositories {
 def versions = [
   junit           : '5.12.2',
   junitPlatform   : '1.12.2',
-  reformLogging   : '6.1.9',
+  reformLogging   : '5.0.1',
   camunda         : '7.17.0',
   pitest          : '1.11.3',
   sonarPitest     : '0.5',
@@ -272,7 +272,8 @@ dependencies {
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging
+  implementation group: 'com.github.hmcts.java-logging', name: 'java-logging-appinsights', version: versions.reformLogging
+  implementation group: 'com.github.hmcts.java-logging', name: 'java-logging-spring', version: versions.reformLogging
 
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j

--- a/build.gradle
+++ b/build.gradle
@@ -273,7 +273,6 @@ dependencies {
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
   implementation group: 'com.github.hmcts.java-logging', name: 'java-logging-appinsights', version: versions.reformLogging
-  implementation group: 'com.github.hmcts.java-logging', name: 'java-logging-spring', version: versions.reformLogging
 
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j

--- a/build.gradle
+++ b/build.gradle
@@ -239,7 +239,6 @@ repositories {
   maven {
     url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
   }
-  //maven { url 'https://jitpack.io' }
   mavenCentral()
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,5 +37,15 @@
     <cve>CVE-2021-29425</cve>
     <cve>CVE-2022-3171</cve>
     <cve>CVE-2021-43797</cve>
+    <cve>CVE-2024-7254</cve>
+    <cve>CVE-2022-3509</cve>
+    <cve>CVE-2024-47554</cve>
+    <cve>CVE-2019-9512</cve>
+    <cve>CVE-2019-9514</cve>
+    <cve>CVE-2019-9515</cve>
+    <cve>CVE-2019-9518</cve>
+    <cve>CVE-2024-29025</cve>
+    <cve>CVE-2022-41915</cve>
+    <cve>CVE-2024-47535</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,5 +15,27 @@
     <cve>CVE-2024-12801</cve>
     <cve>CVE-2025-48734</cve>
     <cve>CVE-2024-22259</cve>
+    <cve>CVE-2022-41881</cve>
+    <cve>CVE-2021-22569</cve>
+    <cve>CVE-2019-20445</cve>
+    <cve>CVE-2022-24823</cve>
+    <cve>CVE-2022-25647</cve>
+    <cve>CVE-2019-20444</cve>
+    <cve>CVE-2021-21295</cve>
+    <cve>CVE-2023-34462</cve>
+    <cve>CVE-2023-44487</cve>
+    <cve>CVE-2021-21290</cve>
+    <cve>CVE-2020-11612</cve>
+    <cve>CVE-2021-37136</cve>
+    <cve>CVE-2021-37137</cve>
+    <cve>CVE-2025-25193</cve>
+    <cve>CVE-2019-16869</cve>
+    <cve>CVE-2020-13956</cve>
+    <cve>CVE-2020-8908</cve>
+    <cve>CVE-2023-2976</cve>
+    <cve>CVE-2021-21409</cve>
+    <cve>CVE-2021-29425</cve>
+    <cve>CVE-2022-3171</cve>
+    <cve>CVE-2021-43797</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -47,5 +47,9 @@
     <cve>CVE-2024-29025</cve>
     <cve>CVE-2022-41915</cve>
     <cve>CVE-2024-47535</cve>
+    <cve>CVE-2024-38808</cve>
+    <cve>CVE-2025-41234</cve>
+    <cve>CVE-2025-48988</cve>
+    <cve>CVE-2025-49125</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until = "2024-11-07">
+  <suppress until = "2025-08-07">
     <cve>CVE-2015-0897</cve>
+    <cve>CVE-2024-38820</cve>
+    <cve>CVE-2025-22235</cve>
+    <cve>CVE-2025-22233</cve>
     <cve>CVE-2016-1000027</cve>
+    <cve>CVE-2024-38828</cve>
+    <cve>CVE-2024-38816</cve>
+    <cve>CVE-2024-45801</cve>
+    <cve>CVE-2024-47875</cve>
+    <cve>CVE-2025-26791</cve>
+    <cve>CVE-2024-12798</cve>
+    <cve>CVE-2024-12801</cve>
+    <cve>CVE-2025-48734</cve>
+    <cve>CVE-2024-22259</cve>
   </suppress>
 </suppressions>

--- a/src/test/java/uk/gov/hmcts/reform/sscstaskconfiguration/dmn/CamundaTaskReadPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscstaskconfiguration/dmn/CamundaTaskReadPermissionTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.sscstaskconfiguration.DmnDecisionTable.WA_TASK_PERMISSIONS_SSCS_BENEFIT;
 
 public class CamundaTaskReadPermissionTest extends DmnDecisionTableBaseUnitTest {


### PR DESCRIPTION
### JIRA link (if applicable) ###

See [SSCSCI-1868](https://tools.hmcts.net/jira/browse/SSCSCI-1868)

### Change description ###

Added `org.apiguardian:apiguardian-api:1.1.2` to resolve build warnings: https://junit.org/junit5/docs/5.1.0-RC1/release-notes/#release-notes-5.1.0-M2-overall-improvements

#### Migrating from JitPack to Azure DevOps Artifacts
| Name | Change |
| --- | --- |
| [com.github.hmcts.java-logging:logging](https://github.com/hmcts/java-logging) | `5.1.7` -> `5.0.1` |
| [com.github.hmcts.java-logging:logging-appinsights](https://github.com/hmcts/java-logging/blob/master/java-logging-appinsights/README.md) | `logging-appinsights:5.1.7` -> `java-logging-appinsights:5.0.1` |

Downgraded logging because only these versions are published to ADO and the new v6 depends on Spring Boot 3.

#### Other updates
| Name | Change |
| --- | --- |
| [org.apache.tomcat.embed](https://tomcat.apache.org/) | `9.0.93` -> `9.0.104`|
| dependency check gradle plugin | `10.0.3` -> `12.1.2` |

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
```
[x] Yes
[ ] No
```

CVE-2015-0897 (Severity: Medium): false positive. CVE is for LINE mobile app, but `org.pitest/pitest-command-line@1.15.0` is flagged in our repo.
CVE-2024-45801 (Severity: High), CVE-2024-47875 (Severity: Critical), CVE-2025-26791 (Severity: Medium): false positive. CVE is for `dompurify` npm package but swagger-ui-bundle 5.11.8 gets flagged

CVE-2024-38816 (Severity: High): patched version (`5.3.40`) is only available commercially. Needs a Spring Boot 3 update
CVE-2024-38820 (Severity: Medium): patched version (`5.3.41`) is only available commercially. Needs a Spring Boot 3 update
CVE-2024-38828 (Severity: Medium): patched version (`5.3.42`) is only available commercially. Needs a Spring Boot 3 update
CVE-2025-22233 (Severity: Low): patched version (`5.3.43`) is only available commercially. Needs a Spring Boot 3 update
CVE-2025-22235 (Severity: High): patched version (`2.7.25`) is only available in Enterprise Support. Needs a Spring Boot 3 update
CVE-2016-1000027 (Severity: Critical): patched version (`2.7.25.1`) is only available in Enterprise Support. Needs a Spring Boot 3 update
etc..

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
